### PR TITLE
Added shprplotfun_read_fonts & removed inital empty space in Rmd & zzz.R

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -15,7 +15,7 @@
   # If the package is installed, we can assume that the intention has been to
   # make relevant fonts available
   } else if (
-      interactive() &&
+      getOption("shprplotfun_read_fonts", default = interactive()) &&
       !"Arial Narrow" %in% extrafont::fonts() &&
       ask("Register 'Arial Narrow' for correct export to PNG?")) {
     extrafont::font_import()

--- a/README.Rmd
+++ b/README.Rmd
@@ -31,3 +31,13 @@ Sometimes it occurs errors with the documention. Might work by restarting the se
 ``` r
 .rs.restartR()
 ```
+
+## Arial narrow extra font
+
+The package requires *Arial Narrow* loaded through the `extrafont` package. This can be time consuming and opted out through the `shprplotfun_read_fonts` option. The default for this `interactive()`. To skip the font option use:
+
+``` r
+options(shprplotfun_read_fonts = FALSE)
+```
+
+Note that in a Linux environment you may need to install the MS fonts, e.g. for Ubuntu run `sudo apt-get install ttf-mscorefonts-installer`.

--- a/README.md
+++ b/README.md
@@ -21,3 +21,17 @@ restarting the session with
 ``` r
 .rs.restartR()
 ```
+
+## Arial narrow extra font
+
+The package requires *Arial Narrow* loaded through the `extrafont`
+package. This can be time consuming and opted out through the
+`shprplotfun_read_fonts` option. The default for this `interactive()`.
+To skip the font option use:
+
+``` r
+options(shprplotfun_read_fonts = FALSE)
+```
+
+Note that in a Linux environment you may need to install the MS fonts,
+e.g. for Ubuntu run `sudo apt-get install ttf-mscorefonts-installer`.


### PR DESCRIPTION
Here's a fix for the font-question during package loading. As I only use the maps (awesome btw!) I prefer to opt. out of the 'Arial Narrow' font.